### PR TITLE
Add clock/timer page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { ProjectsComponent } from './pages/projects/projects.component';
 import { ContactMeComponent } from './pages/contact-me/contact-me.component';
 import { AiAssistantComponent } from './pages/ai-assistant/ai-assistant.component';
 import { VirtualCvComponent } from './pages/virtual-cv/virtual-cv.component';
+import { ClockComponent } from './pages/clock/clock.component';
 export const routes: Routes = [
   {
     path: '',
@@ -36,6 +37,11 @@ export const routes: Routes = [
     path: 'cv',
     component: VirtualCvComponent,
     title: 'Shkrsltnv | CV'
+  },
+  {
+    path: 'clock',
+    component: ClockComponent,
+    title: 'Shkrsltnv | Clock'
   },
   {
     path: '**',

--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -58,6 +58,14 @@
           >{{ "HEADER.CV" | translate }}</a
         >
       </li>
+      <li>
+        <a
+          routerLink="/clock"
+          class="nav-link"
+          (click)="closeMobileMenu()"
+          >{{ "HEADER.CLOCK" | translate }}</a
+        >
+      </li>
       <div class="language-selector">
         <button
           class="language-toggle"

--- a/src/app/pages/clock/clock.component.html
+++ b/src/app/pages/clock/clock.component.html
@@ -1,0 +1,20 @@
+<div class="clock-container container">
+  <app-hero
+    [title]="'HERO_TITLES.CLOCK' | translate"
+    [subtitle]="'HERO_TITLES.CLOCK_SUBTITLE' | translate"
+  ></app-hero>
+
+  <section class="clock-section animate-on-scroll">
+    <div class="time-display">{{ currentTime }}</div>
+    <div class="timer-display">{{ formatTimer() }}</div>
+    <div class="timer-controls">
+      <button (click)="startTimer()" [disabled]="timerRunning">
+        {{ 'CLOCK.START' | translate }}
+      </button>
+      <button (click)="stopTimer()" [disabled]="!timerRunning">
+        {{ 'CLOCK.STOP' | translate }}
+      </button>
+      <button (click)="resetTimer()">{{ 'CLOCK.RESET' | translate }}</button>
+    </div>
+  </section>
+</div>

--- a/src/app/pages/clock/clock.component.scss
+++ b/src/app/pages/clock/clock.component.scss
@@ -1,0 +1,48 @@
+:host {
+  display: block;
+  background-color: #0f0f0f;
+  color: #ffffff;
+  font-family: "Montserrat", sans-serif;
+  overflow: hidden;
+}
+
+.clock-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.clock-section {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+.time-display,
+.timer-display {
+  font-size: 3rem;
+  margin: 1rem 0;
+}
+
+.timer-controls {
+  margin-top: 1rem;
+  button {
+    margin: 0 0.5rem;
+    padding: 0.5rem 1rem;
+    background-color: var(--button-background);
+    color: var(--button-text);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+
+    &:hover:enabled {
+      background-color: var(--button-hover);
+    }
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+}

--- a/src/app/pages/clock/clock.component.ts
+++ b/src/app/pages/clock/clock.component.ts
@@ -1,0 +1,68 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { HeroComponent } from '../../shared/components/hero/hero.component';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-clock',
+  standalone: true,
+  imports: [CommonModule, RouterModule, HeroComponent, TranslateModule],
+  templateUrl: './clock.component.html',
+  styleUrl: './clock.component.scss'
+})
+export class ClockComponent implements OnInit, OnDestroy {
+  currentTime: string = '';
+  timerSeconds = 0;
+  timerRunning = false;
+  private clockInterval?: number;
+  private timerInterval?: number;
+
+  ngOnInit() {
+    this.updateTime();
+    this.clockInterval = window.setInterval(() => this.updateTime(), 1000);
+  }
+
+  ngOnDestroy() {
+    if (this.clockInterval) {
+      clearInterval(this.clockInterval);
+    }
+    this.stopTimer();
+  }
+
+  updateTime() {
+    this.currentTime = new Date().toLocaleTimeString();
+  }
+
+  startTimer() {
+    if (!this.timerRunning) {
+      this.timerRunning = true;
+      this.timerInterval = window.setInterval(() => this.timerSeconds++, 1000);
+    }
+  }
+
+  stopTimer() {
+    if (this.timerRunning) {
+      this.timerRunning = false;
+      if (this.timerInterval) {
+        clearInterval(this.timerInterval);
+      }
+    }
+  }
+
+  resetTimer() {
+    this.stopTimer();
+    this.timerSeconds = 0;
+  }
+
+  formatTimer(): string {
+    const hrs = Math.floor(this.timerSeconds / 3600)
+      .toString()
+      .padStart(2, '0');
+    const mins = Math.floor((this.timerSeconds % 3600) / 60)
+      .toString()
+      .padStart(2, '0');
+    const secs = (this.timerSeconds % 60).toString().padStart(2, '0');
+    return `${hrs}:${mins}:${secs}`;
+  }
+}

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -6,6 +6,7 @@
     "CONTACT": "Kontakt",
     "CV": "Lebenslauf",
     "AI_ASSISTANT": "KI-Assistent",
+    "CLOCK": "Uhr",
     "NAVIGATION": "Navigation"
   },
   "HERO_TITLES": {
@@ -18,7 +19,9 @@
     "PROJECTS": "PROJEKTE",
     "PROJECTS_SUBTITLE": "Schauen wir uns meine Projekte an",
     "CONTACT": "KONTAKT",
-    "CONTACT_SUBTITLE": "Kontaktieren Sie mich"
+    "CONTACT_SUBTITLE": "Kontaktieren Sie mich",
+    "CLOCK": "UHR & TIMER",
+    "CLOCK_SUBTITLE": "Behalte die Zeit im Blick"
   },
   "HOME": {
     "ABOUT_ME": "ÜBER MICH",
@@ -145,6 +148,11 @@
     "WORK_EXPERIENCE": "BERUFLICHER WERDEGANG",
     "CERTIFICATIONS": "ZERTIFIKATE",
     "DOWNLOAD_CV": "CV herunterladen"
+  },
+  "CLOCK": {
+    "START": "Start",
+    "STOP": "Stopp",
+    "RESET": "Zurücksetzen"
   },
   "BUTTONS": {
     "VIEW_CODE": "Code ansehen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -6,6 +6,7 @@
     "CONTACT": "Contact",
     "CV": "CV",
     "AI_ASSISTANT": "AI Assistant",
+    "CLOCK": "Clock",
     "NAVIGATION": "Navigation"
   },
   "HERO_TITLES": {
@@ -18,7 +19,9 @@
     "PROJECTS": "PROJECTS",
     "PROJECTS_SUBTITLE": "Let's take a look at my projects",
     "CONTACT": "CONTACT",
-    "CONTACT_SUBTITLE": "Get in touch"
+    "CONTACT_SUBTITLE": "Get in touch",
+    "CLOCK": "CLOCK & TIMER",
+    "CLOCK_SUBTITLE": "Track time easily"
   },
   "HOME": {
     "ABOUT_ME": "ABOUT ME",
@@ -145,6 +148,11 @@
     "WORK_EXPERIENCE": "WORK EXPERIENCE",
     "CERTIFICATIONS": "CERTIFICATIONS",
     "DOWNLOAD_CV": "Download CV"
+  },
+  "CLOCK": {
+    "START": "Start",
+    "STOP": "Stop",
+    "RESET": "Reset"
   },
   "BUTTONS": {
     "VIEW_CODE": "View Code",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -6,6 +6,7 @@
     "CONTACT": "Контакты",
     "CV": "Резюме",
     "AI_ASSISTANT": "ИИ Ассистент",
+    "CLOCK": "Часы",
     "NAVIGATION": "Навигация"
   },
   "HERO_TITLES": {
@@ -18,7 +19,9 @@
     "PROJECTS": "ПРОЕКТЫ",
     "PROJECTS_SUBTITLE": "Давайте взглянем на мои проекты",
     "CONTACT": "КОНТАКТЫ",
-    "CONTACT_SUBTITLE": "Свяжитесь со мной"
+    "CONTACT_SUBTITLE": "Свяжитесь со мной",
+    "CLOCK": "ЧАСЫ И ТАЙМЕР",
+    "CLOCK_SUBTITLE": "Следите за временем"
   },
   "HOME": {
     "ABOUT_ME": "ОБО МНЕ",
@@ -144,6 +147,11 @@
     "WORK_EXPERIENCE": "ПРОФЕССИОНАЛЬНЫЙ ОПЫТ",
     "CERTIFICATIONS": "СЕРТИФИКАТЫ",
     "DOWNLOAD_CV": "Скачать резюме"
+  },
+  "CLOCK": {
+    "START": "Старт",
+    "STOP": "Стоп",
+    "RESET": "Сброс"
   },
   "BUTTONS": {
     "VIEW_CODE": "Посмотреть код",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -6,6 +6,7 @@
     "CONTACT": "İletişim",
     "CV": "Özgeçmiş",
     "AI_ASSISTANT": "SHAKO AI",
+    "CLOCK": "Saat",
     "NAVIGATION": "Navigasyon"
   },
   "HERO_TITLES": {
@@ -18,7 +19,9 @@
     "PROJECTS": "PROJELER",
     "PROJECTS_SUBTITLE": "Projelerime bir göz atalım",
     "CONTACT": "İLETİŞİM",
-    "CONTACT_SUBTITLE": "Benimle iletişime geçin"
+    "CONTACT_SUBTITLE": "Benimle iletişime geçin",
+    "CLOCK": "SAAT & ZAMANLAYICI",
+    "CLOCK_SUBTITLE": "Zamanı kolayca takip edin"
   },
   "HOME": {
     "ABOUT_ME": "HAKKIMDA",
@@ -145,6 +148,11 @@
     "WORK_EXPERIENCE": "DENEYİM",
     "CERTIFICATIONS": "SERTİFİKALAR",
     "DOWNLOAD_CV": "CV İndir"
+  },
+  "CLOCK": {
+    "START": "Başlat",
+    "STOP": "Durdur",
+    "RESET": "Sıfırla"
   },
   "BUTTONS": {
     "VIEW_CODE": "Kodu Görüntüle",

--- a/src/assets/i18n/ua.json
+++ b/src/assets/i18n/ua.json
@@ -6,6 +6,7 @@
     "CONTACT": "Контакти",
     "CV": "Резюме",
     "AI_ASSISTANT": "ШІ Асистент",
+    "CLOCK": "Годинник",
     "NAVIGATION": "Навігація"
   },
   "HERO_TITLES": {
@@ -18,7 +19,9 @@
     "PROJECTS": "ПРОЄКТИ",
     "PROJECTS_SUBTITLE": "Давайте поглянемо на мої проєкти",
     "CONTACT": "КОНТАКТИ",
-    "CONTACT_SUBTITLE": "Зв'яжіться зі мною"
+    "CONTACT_SUBTITLE": "Зв'яжіться зі мною",
+    "CLOCK": "ГОДИННИК ТА ТАЙМЕР",
+    "CLOCK_SUBTITLE": "Слідкуйте за часом"
   },
   "HOME": {
     "ABOUT_ME": "ПРО МЕНЕ",
@@ -144,6 +147,11 @@
     "WORK_EXPERIENCE": "ДОСВІД РОБОТИ",
     "CERTIFICATIONS": "СЕРТИФІКАЦІЇ",
     "DOWNLOAD_CV": "Завантажити резюме"
+  },
+  "CLOCK": {
+    "START": "Старт",
+    "STOP": "Зупинити",
+    "RESET": "Скинути"
   },
   "BUTTONS": {
     "VIEW_CODE": "Переглянути код",


### PR DESCRIPTION
## Summary
- add new ClockComponent with digital clock and timer controls
- route `/clock` displays the new page
- update header menu
- provide translations for new text in all languages

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run build` *(fails: Could not resolve '../../environments/environment')*

------
https://chatgpt.com/codex/tasks/task_e_683f85ba7fd08321b3a44de1a770a11d